### PR TITLE
Upgrade actions/checkout to v4 (avoids Node.js warning)

### DIFF
--- a/.github/workflows/render_check.yml
+++ b/.github/workflows/render_check.yml
@@ -5,7 +5,7 @@ jobs:
   render_book:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'

--- a/.github/workflows/render_pages.yml
+++ b/.github/workflows/render_pages.yml
@@ -5,7 +5,7 @@ jobs:
   render:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'

--- a/deploy_bookdown/action.yml
+++ b/deploy_bookdown/action.yml
@@ -5,7 +5,7 @@ jobs:
     name: Render-Book
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.2.2'


### PR DESCRIPTION
@jonthegeek 