### PR TITLE
Implement parameter 'extra-repositories' for r-lib/actions/setup-r

### DIFF
--- a/.github/workflows/render_check.yml
+++ b/.github/workflows/render_check.yml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
 
+inputs:
+  extra-repositories:
+    description: 'One or more extra CRAN-like repositories to include in the `repos` global option'
+    default: ''
+
 jobs:
   render_book:
     runs-on: ubuntu-latest
@@ -9,6 +14,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
+          extra-repositories: ${{ inputs.extra-repositories }}
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/render_pages.yml
+++ b/.github/workflows/render_pages.yml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
 
+inputs:
+  extra-repositories:
+    description: 'One or more extra CRAN-like repositories to include in the `repos` global option'
+    default: ''
+
 jobs:
   render:
     runs-on: ubuntu-latest
@@ -9,6 +14,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
+          extra-repositories: ${{ inputs.extra-repositories }}
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/deploy_bookdown/action.yml
+++ b/deploy_bookdown/action.yml
@@ -1,5 +1,10 @@
 name: renderbook
 
+inputs:
+  extra-repositories:
+    description: 'One or more extra CRAN-like repositories to include in the `repos` global option'
+    default: ''
+
 jobs:
   bookdown:
     name: Render-Book
@@ -9,11 +14,11 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.2.2'
+          extra-repositories: ${{ inputs.extra-repositories }}
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 2
-
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
       - uses: actions/upload-pages-artifact@v1

--- a/deploy_bookdown/action.yml
+++ b/deploy_bookdown/action.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: '4.2.2'
+          r-version: 'release'
           extra-repositories: ${{ inputs.extra-repositories }}
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
This should allow passing extra CRAN-like repositories to the r4dsactions, e.g. to install INLA (bookclub-spacestats).

{pak} doesn't support the Additional_repositories field in DESCRIPTION.

Meanwhile also updated the R version parameter of `r-lib/actions/setup-r` in the `deploy_bookdown` action to `'release'` since it was fixed at **4.2.2**, contrary to the other actions in this repo which already used `'release'`.

@jonthegeek 