### PR TITLE
Add Quarto workflows

### DIFF
--- a/.github/workflows/deploy_quarto.yml
+++ b/.github/workflows/deploy_quarto.yml
@@ -1,0 +1,47 @@
+on:
+  workflow_call:
+    inputs:
+      extra-repositories:
+        description: 'One or more extra CRAN-like repositories to include in the `repos` global option'
+        default: ''
+        type: string
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          extra-repositories: ${{ inputs.extra-repositories }}
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache-version: 1
+      - name: Render Book
+        run: Rscript -e 'bookdown::render_book("index.Rmd")'
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: _book/
+
+  deploy:
+    # Add a dependency to the build job
+    needs: render
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy_quarto.yml
+++ b/.github/workflows/deploy_quarto.yml
@@ -1,3 +1,5 @@
+name: Render and deploy Quarto project as book and slides
+
 on:
   workflow_call:
     inputs:
@@ -7,41 +9,24 @@ on:
         type: string
 
 jobs:
-  render:
+  render-quarto:
+    uses: ./.github/workflows/render_quarto.yml
+    
+  deploy-quarto:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: 'release'
-          extra-repositories: ${{ inputs.extra-repositories }}
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          cache-version: 1
-      - name: Render Book
-        run: Rscript -e 'bookdown::render_book("index.Rmd")'
-      - uses: actions/upload-pages-artifact@v1
-        with:
-          path: _book/
-
-  deploy:
-    # Add a dependency to the build job
-    needs: render
+    needs: render-quarto
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write
+      id-token: write
 
     # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    # Specify runner + deployment step
-    runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/render_quarto.yml
+++ b/.github/workflows/render_quarto.yml
@@ -1,3 +1,5 @@
+name: Render Quarto poject as book and slides
+
 on:
   workflow_call:
     inputs:
@@ -7,7 +9,7 @@ on:
         type: string
 
 jobs:
-  render_book:
+  render-quarto:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,9 +17,19 @@ jobs:
         with:
           r-version: 'release'
           extra-repositories: ${{ inputs.extra-repositories }}
-      - uses: r-lib/actions/setup-pandoc@v2
+      # Installs Quarto if repository contains at least one `.qmd` file
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 1
-      - name: Render Book
-        run: Rscript -e 'bookdown::render_book("index.Rmd")'
+      - name: Render Quarto book
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          QUARTO_PROFILE: book
+      - name: Render Quarto revealjs slides
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          QUARTO_PROFILE: slides
+      - name: Create Quarto artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _book/

--- a/.github/workflows/render_quarto.yml
+++ b/.github/workflows/render_quarto.yml
@@ -1,0 +1,23 @@
+on:
+  workflow_call:
+    inputs:
+      extra-repositories:
+        description: 'One or more extra CRAN-like repositories to include in the `repos` global option'
+        default: ''
+        type: string
+
+jobs:
+  render_book:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          extra-repositories: ${{ inputs.extra-repositories }}
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache-version: 1
+      - name: Render Book
+        run: Rscript -e 'bookdown::render_book("index.Rmd")'


### PR DESCRIPTION
Hi,

I am setting up these workflows for another pull request I will make on [r4ds/bookclub-r4ds](https://github.com/r4ds/bookclub-r4ds) converting the project from {bookdown} to Quarto book and slides that will depend on the workflows below (https://github.com/r4ds/bookclub-r4ds/pull/149).

- `.github/workflows/render_quarto.yml`: The reusable workflow assumes two quarto profiles, `_quarto-book.yml` and `_quarto-slides.yml`, to render the project. Book and revealjs slides cannot be rendered as two formats of the same Quarto project, so it was necessary to render each as its profile. Will be used in  [r4ds/bookclub-r4ds](https://github.com/r4ds/bookclub-r4ds) both as a PR check and for publishing as part of `.github/workflows/deploy_quarto.yml`.
- `.github/workflows/deploy_quarto.yml`: I am using a similar approach to publish to GitHub Pages as in `.github/workflows/render_pages.yml`, but it uses ` .github/workflows/render_quarto.yml` for the render step. I tried GHA [quarto-actions/publish@v2](https://github.com/quarto-dev/quarto-actions/tree/main/publish), but it would not detect a Quarto output. Not sure if this was a result of mostly using the Quarto profiles for project settings, e.g., `_quarto.yml` does not define the project `type` or `output-dir`.

Edit: provided PR